### PR TITLE
Added a remote-fallback in case git-lfs isn't available or hasn't been used to synchronize the large test files

### DIFF
--- a/src/flat_bug/tests/test_predictor.py
+++ b/src/flat_bug/tests/test_predictor.py
@@ -40,7 +40,10 @@ TEST_CFG = {
 
 def file_is_lfs_pointer(file):
     with open(file, "r") as f:
-        return bool(re.search(r"git-lfs\.github\.com", f.read()))
+        try:
+            return bool(re.search(r"git-lfs\.github\.com", f.read()))
+        except UnicodeDecodeError:
+            return False
     
 def check_file_with_remote_fallback(file, file_storage : str="https://anon.erda.au.dk/share_redirect/ecgKtuRWe5"):
     if not os.path.exists(file) or file_is_lfs_pointer(file):


### PR DESCRIPTION
This is a simple work-around for handling large test-files, in case the files are a git-lfs pointer, the test script will download the files from a publically available URL on ERDA.

Really the test files should be synchronized using git-lfs `git lfs pull`, however this is merely a fallback for systems where it isn't possible or practical to install `git-lfs`.