### PR TITLE
Fixed unrestricted upper bound on ultralytics dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ micromamba install flat-bug -c conda-forge
 #### Source/development
 Or a development version can be installed from source by cloning this repository:
 ```sh
-git clone git@github.com:darsa-group/flat-bug.git
+git clone https://github.com/darsa-group/flat-bug.git
 cd flat-bug
 pip install -e .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     "torch>=2.2.0",
     "torchvision>=0.17.0",
-    "ultralytics>=8.2.16",
+    "ultralytics>=8.2.16,<=8.3.124",
     "shapely>=2.0.2",
     "scikit-optimize>=0.10.1"
 ]

--- a/src/bin/fb_predict.py
+++ b/src/bin/fb_predict.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""
+r"""
 Inference CLI script for ``flatbug``. 
 
 A comprehensive CLI API for ``flatbug`` inference with support for hyperparameter configuration, flexible input parsing, output format specification, and hardware specification.

--- a/src/bin/fb_predict.py
+++ b/src/bin/fb_predict.py
@@ -291,7 +291,7 @@ def predict(
                     identifier = UUID, #str(uuid.uuid4()),
                 )
                 if not result_directory is None:
-                    json_files = [f for f in glob.glob(os.path.join(glob.escape(result_directory), "*.json"))]
+                    json_files = [f for f in glob.glob(os.path.join(glob.escape(metadata if isinstance(metadata, str) else result_directory), f"*{os.path.splitext(os.path.basename(f))[0]}*.json"))]
                     assert len(json_files) == 1
                     all_json_results.append(json_files[0])
                 if isVideo and overviews:

--- a/src/flat_bug/predictor.py
+++ b/src/flat_bug/predictor.py
@@ -586,7 +586,8 @@ class TensorPredictions:
         params.pop("self", None)
         if outpath not in [None, ""] and outpath.lower().endswith(".svg"):
             retval = self._plot_svg(**params)
-        retval = self._plot_image(**params)
+        else:
+            retval = self._plot_image(**params)
         if retval is None:
             return outpath
         return retval

--- a/src/flat_bug/predictor.py
+++ b/src/flat_bug/predictor.py
@@ -1077,9 +1077,6 @@ class TensorPredictions:
         if prediction_directory_is_used:
             if not os.path.exists(prediction_directory):
                 os.makedirs(prediction_directory)
-        else:
-            # If the prediction directory is not used set it to None
-            return None
 
         # Save overview
         if overview:
@@ -1129,7 +1126,7 @@ class TensorPredictions:
             # Serialize the data to the metadata path
             self.serialize(outpath=metadata_path, identifier=identifier)
 
-        return prediction_directory
+        return prediction_directory if prediction_directory_is_used else None
 
 def _process_batch(
             image : torch.Tensor, 

--- a/src/flat_bug/tests/assets/pyramid_tps_1.pt
+++ b/src/flat_bug/tests/assets/pyramid_tps_1.pt
@@ -1,1 +1,0 @@
-ERDA Pointer

--- a/src/flat_bug/tests/assets/pyramid_tps_2.pt
+++ b/src/flat_bug/tests/assets/pyramid_tps_2.pt
@@ -1,1 +1,0 @@
-ERDA Pointer

--- a/src/flat_bug/tests/assets/pyramid_tps_3.pt
+++ b/src/flat_bug/tests/assets/pyramid_tps_3.pt
@@ -1,1 +1,0 @@
-ERDA Pointer

--- a/src/flat_bug/tests/assets/pyramid_tps_4.pt
+++ b/src/flat_bug/tests/assets/pyramid_tps_4.pt
@@ -1,1 +1,0 @@
-ERDA Pointer

--- a/src/flat_bug/tests/assets/pyramid_tps_5.pt
+++ b/src/flat_bug/tests/assets/pyramid_tps_5.pt
@@ -1,1 +1,0 @@
-ERDA Pointer

--- a/src/flat_bug/tests/assets/single_scale_tps_1.pt
+++ b/src/flat_bug/tests/assets/single_scale_tps_1.pt
@@ -1,1 +1,0 @@
-ERDA Pointer


### PR DESCRIPTION
Set the version requirement for ultralytics to >=8.2.16,<=8.3.124 fixing a breaking change in ultralytics in 8.3.125.

Switched installation guide from git clone via SSH to HTTPs (#121)